### PR TITLE
feat: draw profile direction based on runway

### DIFF
--- a/qAeroChart/core/layer_manager.py
+++ b/qAeroChart/core/layer_manager.py
@@ -986,7 +986,16 @@ class LayerManager:
             ve = float(config.get('style', {}).get('vertical_exaggeration', 10.0))
         except Exception:
             ve = 10.0
-        geometry = ProfileChartGeometry(origin_point, vertical_exaggeration=ve)
+        # Determine horizontal drawing direction based on runway direction
+        dir_text = str(runway.get('direction', '')).strip()
+        try:
+            # Extract numeric runway designator (first two digits)
+            rwy_num = int(''.join(ch for ch in dir_text if ch.isdigit())[:2] or 0)
+        except Exception:
+            rwy_num = 0
+        # If RWY direction <= 18 then draw right→left (dir_sign = -1), else left→right
+        dir_sign = -1 if rwy_num and rwy_num <= 18 else 1
+        geometry = ProfileChartGeometry(origin_point, vertical_exaggeration=ve, horizontal_direction=dir_sign)
         
         # BATCH OPERATIONS: Collect all features first, then add in bulk
         point_features = []

--- a/qAeroChart/qaerochart_dockwidget.py
+++ b/qAeroChart/qaerochart_dockwidget.py
@@ -737,7 +737,14 @@ class QAeroChartDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
             
             from .core.profile_chart_geometry import ProfileChartGeometry
             # Use the same default VE as runtime population (10x) for preview
-            geometry = ProfileChartGeometry(origin_point, vertical_exaggeration=10.0)
+            # Determine direction sign from current runway direction
+            dir_text = form.lineEdit_direction.text().strip() if hasattr(form, 'lineEdit_direction') else ""
+            try:
+                rwy_num = int(''.join(ch for ch in dir_text if ch.isdigit())[:2] or 0)
+            except Exception:
+                rwy_num = 0
+            dir_sign = -1 if rwy_num and rwy_num <= 18 else 1
+            geometry = ProfileChartGeometry(origin_point, vertical_exaggeration=10.0, horizontal_direction=dir_sign)
             
             # Profile polyline
             profile_line = geometry.create_profile_line(profile_points)


### PR DESCRIPTION
# Summary: 
The profile chart now draws left→right or right→left based on the runway direction. If the runway designator is ≤ 18, the chart draws right→left; otherwise it draws left→right. Preview in the dock widget matches the final rendering.