### PR TITLE
Task: Ability to Reorder Profile Points (#37)

### DIFF
--- a/qAeroChart/qaerochart_dockwidget.py
+++ b/qAeroChart/qaerochart_dockwidget.py
@@ -24,7 +24,7 @@
 import os
 
 from qgis.PyQt import QtWidgets, uic
-from qgis.PyQt.QtCore import pyqtSignal, Qt
+from qgis.PyQt.QtCore import pyqtSignal, Qt, QItemSelectionModel
 from qgis.PyQt.QtWidgets import QTableWidgetItem, QFileDialog, QMessageBox, QShortcut
 from qgis.PyQt.QtGui import QKeySequence
 from qgis.core import Qgis, QgsPointXY
@@ -533,9 +533,15 @@ class QAeroChartDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         table.clearSelection()
         for r in selected:
             new_r = max(0, r - 1)
-            for c in range(table.columnCount()):
-                idx = table.model().index(new_r, c)
-                table.selectionModel().select(idx, QItemSelectionModel.Select)
+            # Select the entire moved row and keep focus on first column
+            try:
+                table.selectRow(new_r)
+            except Exception:
+                # Fallback: select cells if selectRow unavailable
+                for c in range(table.columnCount()):
+                    idx = table.model().index(new_r, c)
+                    table.selectionModel().select(idx, QItemSelectionModel.Select)
+            table.setCurrentCell(new_r, 0)
 
     def _on_move_row_down(self):
         """Move selected row(s) down, preserving order."""
@@ -558,9 +564,15 @@ class QAeroChartDockWidget(QtWidgets.QDockWidget, FORM_CLASS):
         table.clearSelection()
         for r in selected:
             new_r = min(row_count - 1, r + 1)
-            for c in range(table.columnCount()):
-                idx = table.model().index(new_r, c)
-                table.selectionModel().select(idx, QItemSelectionModel.Select)
+            # Select the entire moved row and keep focus on first column
+            try:
+                table.selectRow(new_r)
+            except Exception:
+                # Fallback: select cells if selectRow unavailable
+                for c in range(table.columnCount()):
+                    idx = table.model().index(new_r, c)
+                    table.selectionModel().select(idx, QItemSelectionModel.Select)
+            table.setCurrentCell(new_r, 0)
     
     # ========== Configuration Save/Load Methods ==========
     


### PR DESCRIPTION
## Summary

Fixes row reordering in the embedded profile form. Resolves a runtime error when moving points and improves UX by keeping the moved row selected and focused, allowing repeated moves without having to reselect.

Closes #37.