### PR TITLE
#38: Fix F2 rename NameError and enable in-place rename

### DIFF
--- a/qAeroChart/qaerochart_dockwidget.py
+++ b/qAeroChart/qaerochart_dockwidget.py
@@ -25,7 +25,7 @@ import os
 
 from qgis.PyQt import QtWidgets, uic
 from qgis.PyQt.QtCore import pyqtSignal, Qt, QItemSelectionModel
-from qgis.PyQt.QtWidgets import QTableWidgetItem, QFileDialog, QMessageBox, QShortcut
+from qgis.PyQt.QtWidgets import QTableWidgetItem, QFileDialog, QMessageBox, QShortcut, QInputDialog
 from qgis.PyQt.QtGui import QKeySequence
 from qgis.core import Qgis, QgsPointXY
 from qgis.utils import iface


### PR DESCRIPTION
# Summary:
 Fixes a NameError when pressing F2 to rename profiles (missing QInputDialog import) and enables renaming existing profiles without recreating them, preserving manual edits