### PR TITLE
fix: remove table actions from map canvas toolbar (#91)

### DIFF
--- a/qAeroChart/qaerochart.py
+++ b/qAeroChart/qaerochart.py
@@ -283,7 +283,8 @@ class QAeroChart:
         self.gs_rod_action.setObjectName('qAeroChartGsRodTableAction')
         self.gs_rod_action.setStatusTip(self.tr('Create a Ground Speed / Rate of Descent table'))
         self.gs_rod_action.triggered.connect(self._open_gs_rod_table_builder)
-        self.tools_toolbar.addAction(self.gs_rod_action)
+        # gs_rod_action is available via the top menu and the Layout Designer toolbar;
+        # it is intentionally NOT added to the map canvas toolbar (#91)
 
         # Layout toolbar action: add distance/altitude table into print layout
         dat_icon_path = os.path.join(self.plugin_dir, 'icons', 'icon_distance_table.svg')
@@ -293,7 +294,8 @@ class QAeroChart:
         self.distance_table_action.setObjectName('qAeroChartDistanceTableAction')
         self.distance_table_action.setStatusTip(self.tr('Insert a distance/altitude table into the active layout'))
         self.distance_table_action.triggered.connect(self._open_distance_table_builder)
-        self.tools_toolbar.addAction(self.distance_table_action)
+        # distance_table_action is available via the top menu and the Layout Designer toolbar;
+        # it is intentionally NOT added to the map canvas toolbar (#91)
         # Also hook into layout-designer openings to force-add the action to their toolbars
         try:
             self.iface.layoutDesignerOpened.connect(self._on_layout_designer_opened)
@@ -317,7 +319,8 @@ class QAeroChart:
         self.oca_h_table_action.setObjectName('qAeroChartOcaHTableAction')
         self.oca_h_table_action.setStatusTip(self.tr('Insert an OCA/H table into the active layout'))
         self.oca_h_table_action.triggered.connect(self._open_oca_h_table_builder)
-        self.tools_toolbar.addAction(self.oca_h_table_action)
+        # oca_h_table_action is available via the top menu and the Layout Designer toolbar;
+        # it is intentionally NOT added to the map canvas toolbar (#91)
         try:
             if self.top_menu:
                 self.top_menu.addAction(self.oca_h_table_action)


### PR DESCRIPTION
# PR: Issue #91 — Remove Table Icons from Map Canvas Toolbar

## Summary

The GS/Rate-of-Descent, Distance/Altitude, and OCA/H table actions were added to the map canvas toolbar in a previous sprint for completeness, but these tools are only meaningful in the Print Layout Designer context. Keeping them on the map canvas toolbar clutters the UI without adding any benefit. This PR removes the three `tools_toolbar.addAction()` calls while keeping the actions reachable through the **qAeroChart top menu** and the dedicated **Layout Designer "qAeroChart tools" toolbar**.

---

## Scope

| Issue | Title                                | Status      |
| ----- | ------------------------------------ | ----------- |
| #91   | Remove icons from map canvas toolbar | ✅ Complete |

---

## Map Canvas Toolbar — Before / After

| Position | Before                  | After            |
| -------- | ----------------------- | ---------------- |
| 1        | Generate Profile        | Generate Profile |
| 2        | Vertical Scale          | Vertical Scale   |
| 3        | Horizontal Scale        | Horizontal Scale |
| 4        | GS/ROD Table            | _(removed)_      |
| 5        | Distance/Altitude Table | _(removed)_      |
| 6        | OCA/H Table             | _(removed)_      |

---

## Where the Actions Are Still Available

| Surface                                        | Actions present                                    |
| ---------------------------------------------- | -------------------------------------------------- |
| **qAeroChart top menu**                        | GS/ROD Table, Distance/Altitude Table, OCA/H Table |
| **Layout Designer "qAeroChart tools" toolbar** | Distance/Altitude Table, GS/ROD Table, OCA/H Table |

---

## Modified Files

### `qAeroChart/qaerochart.py`

Removed three `self.tools_toolbar.addAction(...)` calls from `initGui()`:

```python
# Removed:
self.tools_toolbar.addAction(self.gs_rod_action)
self.tools_toolbar.addAction(self.distance_table_action)
self.tools_toolbar.addAction(self.oca_h_table_action)
```

Each removal is accompanied by a comment explaining the table actions are intentionally absent from the map canvas toolbar and accessible via the top menu and Layout Designer toolbar.

No other logic was changed — actions are still created, connected, and registered with the menu and layout hook exactly as before.

---

## Tests

No new tests required — no logic changed, only toolbar registration removed. Existing test suite confirms no regressions.

**Total test suite: 395 tests passing.**

---

## Commits

```
9fcf84c fix: remove table actions from map canvas toolbar (#91)
```

---

## Manual Smoke Test Checklist

- [ ] Open QGIS with the plugin enabled.
- [ ] Confirm the map canvas "qAeroChart tools" toolbar shows only: Generate Profile, Vertical Scale, Horizontal Scale.
- [ ] Confirm the **qAeroChart top menu** still lists GS/ROD Table, Distance/Altitude Table, OCA/H Table.
- [ ] Open a print layout — confirm the Layout Designer "qAeroChart tools" toolbar shows all three table icons.
- [ ] Click each table action from the menu and Layout Designer toolbar — confirm the respective dialogs open correctly.
