### PR TITLE
Table Item Naming & Table Bug Fixes (#70)

### DIFF
--- a/qAeroChart/core/layout_manager.py
+++ b/qAeroChart/core/layout_manager.py
@@ -25,6 +25,7 @@ from .distance_altitude_table import build_table_rows, compute_column_widths, ex
 
 # Layout-item custom property that identifies the table so it can be replaced
 _TABLE_PROPERTY = "distance_altitude_table"
+_TABLE_ID_PREFIX = "distance_table_"
 
 # Frame geometry (mm) — taken directly from the original script
 _TOTAL_WIDTH_MM = 180.20
@@ -47,6 +48,21 @@ class LayoutManager:
 
     # Name used when a new layout must be created
     LAYOUT_NAME = "AeroChart"
+
+    @staticmethod
+    def _next_table_id(layout, prefix: str) -> str:
+        """Return the next sequential item ID for *prefix* in *layout*."""
+        max_n = 0
+        for item in layout.items():
+            try:
+                item_id = item.id()
+                if item_id.startswith(prefix):
+                    n = int(item_id[len(prefix):])
+                    if n > max_n:
+                        max_n = n
+            except (AttributeError, ValueError):
+                pass
+        return f"{prefix}{max_n + 1:03d}"
 
     def get_or_create_layout(self) -> QgsPrintLayout:
         """Return the first existing print layout or create one called ``AeroChart``.
@@ -94,14 +110,13 @@ class LayoutManager:
         layout = self.get_or_create_layout()
 
         # Remove existing table (if any) so re-running is idempotent
-        for item in layout.items():
+        for mf in list(layout.multiFrames()):
             if (
-                hasattr(item, "customProperty")
-                and item.customProperty("name") == _TABLE_PROPERTY
+                hasattr(mf, "customProperty")
+                and mf.customProperty("name") == _TABLE_PROPERTY
             ):
-                layout.removeLayoutItem(item)
+                layout.removeMultiFrame(mf)
                 log("LayoutManager: removed existing distance_altitude_table")
-                break
 
         # Build the manual table
         t = QgsLayoutItemManualTable.create(layout)
@@ -143,7 +158,17 @@ class LayoutManager:
         frame.attemptMove(
             QgsLayoutPoint(_FRAME_X_MM, _FRAME_Y_MM, layout_unit)
         )
+
+        item_id = self._next_table_id(layout, _TABLE_ID_PREFIX)
+        frame.setId(item_id)
+        try:
+            frame.setDisplayName(item_id)
+        except Exception:
+            pass
+
         t.addFrame(frame)
+
+        layout.refresh()
 
         log(
             f"LayoutManager: table added ({len(numeric_columns)} numeric columns, "

--- a/qAeroChart/qaerochart.py
+++ b/qAeroChart/qaerochart.py
@@ -486,6 +486,18 @@ class QAeroChart:
             pass
         return None
 
+    def _safe_insert(self, insert_fn, dlg) -> None:
+        """Call *insert_fn* and catch errors so a failed insert never crashes the plugin."""
+        try:
+            insert_fn(dlg, self.iface)
+        except Exception as exc:
+            try:
+                self.iface.messageBar().pushCritical(
+                    "qAeroChart", f"Table insert failed: {exc}",
+                )
+            except Exception:
+                print(f"PLUGIN qAeroChart ERROR: Table insert failed: {exc}")
+
     def _open_oca_h_table_builder(self):
         """Launch the OCA/H table builder dialog (issue #74: non-blocking)."""
         try:
@@ -513,7 +525,7 @@ class QAeroChart:
             parent=parent_window,
             default_layout_name=default_layout,
         )
-        dlg.accepted.connect(lambda: table_oca_h.insert_from_dialog(dlg, self.iface))
+        dlg.accepted.connect(lambda: self._safe_insert(table_oca_h.insert_from_dialog, dlg))
         dlg.finished.connect(lambda _: setattr(self, '_oca_h_dialog', None))
         self._oca_h_dialog = dlg
         dlg.show()
@@ -560,7 +572,7 @@ class QAeroChart:
             parent=parent_window,
             default_layout_name=default_layout,
         )
-        dlg.accepted.connect(lambda: table_distance_altitude.insert_from_dialog(dlg, self.iface))
+        dlg.accepted.connect(lambda: self._safe_insert(table_distance_altitude.insert_from_dialog, dlg))
         dlg.finished.connect(lambda _: setattr(self, '_distance_dialog', None))
         self._distance_dialog = dlg
         dlg.show()
@@ -582,12 +594,20 @@ class QAeroChart:
             return
 
         default_layout = self._active_layout_name()
+        parent_window = None
+        try:
+            designer = self.iface.activeLayoutDesignerInterface()
+            if designer is not None:
+                parent_window = designer.window()
+        except Exception:
+            parent_window = None
+
         dlg = table_gs_rod.build_dialog(
             iface=self.iface,
-            parent=None,
+            parent=parent_window,
             default_layout_name=default_layout,
         )
-        dlg.accepted.connect(lambda: table_gs_rod.insert_from_dialog(dlg, self.iface))
+        dlg.accepted.connect(lambda: self._safe_insert(table_gs_rod.insert_from_dialog, dlg))
         dlg.finished.connect(lambda _: setattr(self, '_gs_rod_dialog', None))
         self._gs_rod_dialog = dlg
         dlg.show()

--- a/qAeroChart/scripts/table_distance_altitude.py
+++ b/qAeroChart/scripts/table_distance_altitude.py
@@ -33,6 +33,22 @@ from qAeroChart.utils.qt_compat import QgsUnitTypes
 from qAeroChart.ui.distance_altitude_table_dialog import DistanceAltitudeTableDialog
 
 TABLE_NAME = "distance_altitude_table"
+TABLE_ID_PREFIX = "distance_table_"
+
+
+def _next_table_id(layout, prefix: str) -> str:
+    """Return the next sequential item ID for *prefix* in *layout*."""
+    max_n = 0
+    for item in layout.items():
+        try:
+            item_id = item.id()
+            if item_id.startswith(prefix):
+                n = int(item_id[len(prefix):])
+                if n > max_n:
+                    max_n = n
+        except (AttributeError, ValueError):
+            pass
+    return f"{prefix}{max_n + 1:03d}"
 
 
 def _calc_column_widths(total_width, first_col_width, num_columns, stroke_width, cell_margin):
@@ -66,10 +82,9 @@ def _get_or_create_layout(name, project):
 
 
 def _remove_existing_table(layout):
-    for item in layout.items():
-        if hasattr(item, "customProperty") and item.customProperty("name") == TABLE_NAME:
-            layout.removeLayoutItem(item)
-            break
+    for mf in list(layout.multiFrames()):
+        if hasattr(mf, "customProperty") and mf.customProperty("name") == TABLE_NAME:
+            layout.removeMultiFrame(mf)
 
 
 def _build_table(table_rows, cfg, layout):
@@ -130,6 +145,14 @@ def _build_table(table_rows, cfg, layout):
         QgsLayoutSize(cfg["total_width"], computed_height, QgsUnitTypes.LayoutMillimeters)
     )
     frame.attemptMove(QgsLayoutPoint(x_pos, y_pos, QgsUnitTypes.LayoutMillimeters))
+
+    item_id = _next_table_id(layout, TABLE_ID_PREFIX)
+    frame.setId(item_id)
+    try:
+        frame.setDisplayName(item_id)
+    except Exception:
+        pass
+
     t.addFrame(frame)
 
     return t
@@ -159,12 +182,9 @@ def insert_from_dialog(dlg, iface=None):
         cfg = {**cfg, "layout_name": layout_name}
     project = QgsProject.instance()
     layout = _get_or_create_layout(layout_name, project)
-    try:
-        dlg.set_layout(layout)
-    except Exception:
-        pass
     _remove_existing_table(layout)
     _build_table(table_rows, cfg, layout)
+    layout.refresh()
     if iface:
         iface.messageBar().pushInfo(
             "Distance/Altitude",

--- a/qAeroChart/scripts/table_gs_rod.py
+++ b/qAeroChart/scripts/table_gs_rod.py
@@ -31,11 +31,27 @@ from qAeroChart.utils.qt_compat import QgsUnitTypes, Qt
 from qAeroChart.ui.gs_rod_dialog import GsRodTableDialog
 
 TABLE_NAME = "gs_rod_table"
+TABLE_ID_PREFIX = "gs_table_"
 
 
 # ------------------------------------------------------------------
 # Internal helpers (mirror table_distance_altitude.py)
 # ------------------------------------------------------------------
+
+def _next_table_id(layout, prefix: str) -> str:
+    """Return the next sequential item ID for *prefix* in *layout*."""
+    max_n = 0
+    for item in layout.items():
+        try:
+            item_id = item.id()
+            if item_id.startswith(prefix):
+                n = int(item_id[len(prefix):])
+                if n > max_n:
+                    max_n = n
+        except (AttributeError, ValueError):
+            pass
+    return f"{prefix}{max_n + 1:03d}"
+
 
 def _calc_column_widths(
     total_width: float,
@@ -114,10 +130,9 @@ def _get_or_create_layout(name: str, project):
 
 
 def _remove_existing_table(layout) -> None:
-    for item in layout.items():
-        if hasattr(item, "customProperty") and item.customProperty("name") == TABLE_NAME:
-            layout.removeLayoutItem(item)
-            break
+    for mf in list(layout.multiFrames()):
+        if hasattr(mf, "customProperty") and mf.customProperty("name") == TABLE_NAME:
+            layout.removeMultiFrame(mf)
 
 
 def _build_table(table_rows: list[list[str]], cfg: dict, layout) -> None:
@@ -175,6 +190,14 @@ def _build_table(table_rows: list[list[str]], cfg: dict, layout) -> None:
         QgsLayoutSize(cfg["total_width"], computed_height, QgsUnitTypes.LayoutMillimeters)
     )
     frame.attemptMove(QgsLayoutPoint(x_pos, y_pos, QgsUnitTypes.LayoutMillimeters))
+
+    item_id = _next_table_id(layout, TABLE_ID_PREFIX)
+    frame.setId(item_id)
+    try:
+        frame.setDisplayName(item_id)
+    except Exception:
+        pass
+
     t.addFrame(frame)
 
 
@@ -202,6 +225,7 @@ def insert_from_dialog(dlg: GsRodTableDialog, iface=None) -> None:
     layout = _get_or_create_layout(layout_name, project)
     _remove_existing_table(layout)
     _build_table(table_rows, cfg, layout)
+    layout.refresh()
     n_cols = len(table_rows[0]) - 2 if table_rows else 0  # subtract label + unit cols
     if iface:
         iface.messageBar().pushInfo(

--- a/qAeroChart/scripts/table_oca_h.py
+++ b/qAeroChart/scripts/table_oca_h.py
@@ -28,11 +28,27 @@ from qAeroChart.ui.oca_h_dialog import OcaHTableDialog
 from qAeroChart.utils.qt_compat import Qt, QgsUnitTypes
 
 TABLE_NAME = "oca_h_table"
+TABLE_ID_PREFIX = "oca_table_"
 
 
 # ------------------------------------------------------------------
 # Internal helpers
 # ------------------------------------------------------------------
+
+def _next_table_id(layout, prefix: str) -> str:
+    """Return the next sequential item ID for *prefix* in *layout*."""
+    max_n = 0
+    for item in layout.items():
+        try:
+            item_id = item.id()
+            if item_id.startswith(prefix):
+                n = int(item_id[len(prefix):])
+                if n > max_n:
+                    max_n = n
+        except (AttributeError, ValueError):
+            pass
+    return f"{prefix}{max_n + 1:03d}"
+
 
 def _calc_column_widths(
     total_width: float,
@@ -109,10 +125,9 @@ def _get_or_create_layout(name: str, project) -> QgsPrintLayout:
 
 
 def _remove_existing_table(layout) -> None:
-    for item in layout.items():
-        if hasattr(item, "customProperty") and item.customProperty("name") == TABLE_NAME:
-            layout.removeLayoutItem(item)
-            break
+    for mf in list(layout.multiFrames()):
+        if hasattr(mf, "customProperty") and mf.customProperty("name") == TABLE_NAME:
+            layout.removeMultiFrame(mf)
 
 
 def _build_table(table_rows: list[list[str]], cfg: dict, layout) -> None:
@@ -125,6 +140,11 @@ def _build_table(table_rows: list[list[str]], cfg: dict, layout) -> None:
         pass
     t.setGridColor(QColor(0, 0, 0, 255))
     t.setCustomProperty("name", TABLE_NAME)
+
+    text_format = QgsTextFormat()
+    text_format.setFont(QFont(cfg["font_family"]))
+    text_format.setSize(cfg["font_size"])
+    t.setContentTextFormat(text_format)
 
     layout.addMultiFrame(t)
 
@@ -170,6 +190,14 @@ def _build_table(table_rows: list[list[str]], cfg: dict, layout) -> None:
     frame.attemptMove(
         QgsLayoutPoint(x_pos, y_pos, QgsUnitTypes.LayoutMillimeters)
     )
+
+    item_id = _next_table_id(layout, TABLE_ID_PREFIX)
+    frame.setId(item_id)
+    try:
+        frame.setDisplayName(item_id)
+    except Exception:
+        pass
+
     t.addFrame(frame)
 
 
@@ -197,6 +225,7 @@ def insert_from_dialog(dlg: OcaHTableDialog, iface=None) -> None:
     layout = _get_or_create_layout(layout_name, project)
     _remove_existing_table(layout)
     _build_table(table_rows, cfg, layout)
+    layout.refresh()
     n_data = len(table_rows)
     if iface:
         iface.messageBar().pushInfo(

--- a/qAeroChart/ui/distance_altitude_table_dialog.py
+++ b/qAeroChart/ui/distance_altitude_table_dialog.py
@@ -18,7 +18,6 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
         self.setWindowTitle("Distance/Altitude Table")
         # Non-modal so the layout window does not minimize
         self.setWindowModality(Qt.NonModal)
-        self.setModal(False)
         self.resize(720, 560)
         self._style_manager = TableStyleManager()
         self._build_ui()
@@ -261,8 +260,10 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
         try:
             from qgis.core import QgsLayoutItemManualTable, QgsLayoutFrame
 
-            items = self._layout.items()
-            tables = [it for it in items if isinstance(it, QgsLayoutItemManualTable)]
+            tables = [
+                mf for mf in self._layout.multiFrames()
+                if isinstance(mf, QgsLayoutItemManualTable)
+            ]
             if not tables:
                 self.combo_existing.addItem("(no tables in layout)")
                 return
@@ -403,6 +404,7 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
                 self.combo_layouts.addItem("(no layouts found)")
         except Exception:
             self.combo_layouts.addItem("(no layouts found)")
+        self._attach_current_layout()
 
     def _load_json(self):
         path, _ = QtWidgets.QFileDialog.getOpenFileName(self, "Select Table JSON", "", "JSON Files (*.json)")

--- a/qAeroChart/ui/gs_rod_dialog.py
+++ b/qAeroChart/ui/gs_rod_dialog.py
@@ -24,7 +24,6 @@ class GsRodTableDialog(QtWidgets.QDialog):
         self.iface = iface
         self.setWindowTitle("GS / Rate of Descent Table")
         self.setWindowModality(Qt.NonModal)
-        self.setModal(False)
         self.resize(760, 540)
         self._build_ui()
         self._refresh_preview()

--- a/qAeroChart/ui/oca_h_dialog.py
+++ b/qAeroChart/ui/oca_h_dialog.py
@@ -32,7 +32,6 @@ class OcaHTableDialog(QtWidgets.QDialog):
         self.iface = iface
         self.setWindowTitle("OCA/H Table")
         self.setWindowModality(Qt.NonModal)
-        self.setModal(False)
         self.resize(800, 580)
         self._build_ui()
         self._populate_defaults()

--- a/tests/test_table_item_naming.py
+++ b/tests/test_table_item_naming.py
@@ -1,0 +1,175 @@
+"""Tests for table item naming (#70) and table bug fixes (Bug A–E)."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from qAeroChart.scripts.table_distance_altitude import (
+    TABLE_ID_PREFIX as DAT_PREFIX,
+    TABLE_NAME as DAT_TABLE_NAME,
+    _next_table_id as dat_next_id,
+    _remove_existing_table as dat_remove,
+)
+from qAeroChart.scripts.table_gs_rod import (
+    TABLE_ID_PREFIX as GS_PREFIX,
+    TABLE_NAME as GS_TABLE_NAME,
+    _next_table_id as gs_next_id,
+    _remove_existing_table as gs_remove,
+)
+from qAeroChart.scripts.table_oca_h import (
+    TABLE_ID_PREFIX as OCA_PREFIX,
+    TABLE_NAME as OCA_TABLE_NAME,
+    _next_table_id as oca_next_id,
+    _remove_existing_table as oca_remove,
+)
+
+
+# ---------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------
+
+def _mock_item(item_id: str) -> MagicMock:
+    """Create a mock layout item with the given id()."""
+    m = MagicMock()
+    m.id.return_value = item_id
+    return m
+
+
+def _mock_multiframe(name_prop: str | None = None) -> MagicMock:
+    """Create a mock multiframe with an optional customProperty('name')."""
+    mf = MagicMock()
+    mf.customProperty.side_effect = lambda key: name_prop if key == "name" else None
+    return mf
+
+
+# ===================================================================
+# _next_table_id — unit tests
+# ===================================================================
+
+class TestNextTableId:
+    """Verify _next_table_id returns correct sequential IDs."""
+
+    @pytest.mark.parametrize("next_fn,prefix", [
+        (dat_next_id, DAT_PREFIX),
+        (gs_next_id, GS_PREFIX),
+        (oca_next_id, OCA_PREFIX),
+    ])
+    def test_no_existing_items(self, next_fn, prefix):
+        layout = MagicMock()
+        layout.items.return_value = []
+        assert next_fn(layout, prefix) == f"{prefix}001"
+
+    @pytest.mark.parametrize("next_fn,prefix", [
+        (dat_next_id, DAT_PREFIX),
+        (gs_next_id, GS_PREFIX),
+        (oca_next_id, OCA_PREFIX),
+    ])
+    def test_one_existing(self, next_fn, prefix):
+        layout = MagicMock()
+        layout.items.return_value = [_mock_item(f"{prefix}001")]
+        assert next_fn(layout, prefix) == f"{prefix}002"
+
+    def test_gaps_in_sequence(self):
+        layout = MagicMock()
+        layout.items.return_value = [
+            _mock_item(f"{DAT_PREFIX}001"),
+            _mock_item(f"{DAT_PREFIX}003"),
+        ]
+        assert dat_next_id(layout, DAT_PREFIX) == f"{DAT_PREFIX}004"
+
+    def test_ignores_other_prefixes(self):
+        layout = MagicMock()
+        layout.items.return_value = [_mock_item(f"{GS_PREFIX}001")]
+        assert dat_next_id(layout, DAT_PREFIX) == f"{DAT_PREFIX}001"
+
+    def test_handles_non_numeric_suffix(self):
+        item = MagicMock()
+        item.id.return_value = f"{DAT_PREFIX}abc"
+        layout = MagicMock()
+        layout.items.return_value = [item]
+        assert dat_next_id(layout, DAT_PREFIX) == f"{DAT_PREFIX}001"
+
+    def test_handles_item_without_id(self):
+        item = MagicMock(spec=[])
+        layout = MagicMock()
+        layout.items.return_value = [item]
+        assert dat_next_id(layout, DAT_PREFIX) == f"{DAT_PREFIX}001"
+
+    def test_zero_padded_three_digits(self):
+        layout = MagicMock()
+        layout.items.return_value = []
+        result = dat_next_id(layout, DAT_PREFIX)
+        suffix = result[len(DAT_PREFIX):]
+        assert len(suffix) == 3
+        assert suffix == "001"
+
+
+# ===================================================================
+# _remove_existing_table — Bug A fix tests
+# ===================================================================
+
+class TestRemoveExistingTable:
+    """Verify _remove_existing_table uses multiFrames(), not items()."""
+
+    @pytest.mark.parametrize("remove_fn,table_name", [
+        (dat_remove, DAT_TABLE_NAME),
+        (gs_remove, GS_TABLE_NAME),
+        (oca_remove, OCA_TABLE_NAME),
+    ])
+    def test_removes_matching_multiframe(self, remove_fn, table_name):
+        mf = _mock_multiframe(table_name)
+        layout = MagicMock()
+        layout.multiFrames.return_value = [mf]
+
+        remove_fn(layout)
+
+        layout.removeMultiFrame.assert_called_once_with(mf)
+
+    @pytest.mark.parametrize("remove_fn,table_name", [
+        (dat_remove, DAT_TABLE_NAME),
+        (gs_remove, GS_TABLE_NAME),
+        (oca_remove, OCA_TABLE_NAME),
+    ])
+    def test_noop_when_no_match(self, remove_fn, table_name):
+        mf = _mock_multiframe("some_other_table")
+        layout = MagicMock()
+        layout.multiFrames.return_value = [mf]
+
+        remove_fn(layout)
+
+        layout.removeMultiFrame.assert_not_called()
+
+    @pytest.mark.parametrize("remove_fn", [dat_remove, gs_remove, oca_remove])
+    def test_noop_when_empty(self, remove_fn):
+        layout = MagicMock()
+        layout.multiFrames.return_value = []
+
+        remove_fn(layout)
+
+        layout.removeMultiFrame.assert_not_called()
+
+    def test_removes_all_matching_multiframes(self):
+        mf1 = _mock_multiframe(DAT_TABLE_NAME)
+        mf2 = _mock_multiframe(DAT_TABLE_NAME)
+        layout = MagicMock()
+        layout.multiFrames.return_value = [mf1, mf2]
+
+        dat_remove(layout)
+
+        assert layout.removeMultiFrame.call_count == 2
+
+
+# ===================================================================
+# TABLE_ID_PREFIX constants
+# ===================================================================
+
+class TestPrefixConstants:
+    def test_distance_table_prefix(self):
+        assert DAT_PREFIX == "distance_table_"
+
+    def test_gs_table_prefix(self):
+        assert GS_PREFIX == "gs_table_"
+
+    def test_oca_table_prefix(self):
+        assert OCA_PREFIX == "oca_table_"


### PR DESCRIPTION
# PR: Table Item Naming & Table Bug Fixes (#70)

## Summary

Implements unique naming convention for layout table items and fixes 5 bugs discovered during review that prevented tables from reloading, refreshing, and rendering correctly.

## Changes

### Feature: Table Item Naming (#70)

Each table inserted into a QGIS print layout now receives a unique, sequential, human-readable ID visible in both the **Items panel** and the **Item ID** field in Properties:

| Table type | Prefix | Example |
|---|---|---|
| Distance/Altitude | `distance_table_` | `distance_table_001` |
| GS/Rate of Descent | `gs_table_` | `gs_table_001` |
| OCA/H | `oca_table_` | `oca_table_001` |

- `TABLE_ID_PREFIX` constant added to each script
- `_next_table_id(layout, prefix)` scans existing layout items, finds the highest number for the prefix, and returns `prefix + (max+1)` zero-padded to 3 digits
- `frame.setId(item_id)` sets the Item ID field
- `frame.setDisplayName(item_id)` sets the Items panel label (wrapped in try/except for QGIS version safety)

### Bug A (CRITICAL): `_remove_existing_table` never removed old tables

**Root cause:** `layout.items()` only returns `QgsLayoutItem` subclasses (frames, labels, etc). `QgsLayoutItemManualTable` is a `QgsLayoutMultiFrame` — it lives in `layout.multiFrames()`, not `layout.items()`. The `customProperty("name")` check was always False.

**Symptom:** Every re-insert silently stacked a new table on top. Phantom duplicates accumulated in the layout file.

**Fix:** Changed all 4 `_remove_existing_table` implementations to iterate `layout.multiFrames()` and call `layout.removeMultiFrame(mf)`. Also removed the `break` statement so ALL matching duplicates are cleaned up (not just the first).

### Bug B (CRITICAL): Layout Designer view didn't update after insert

**Root cause:** The Python API updates the layout data model, but open designer windows don't re-render automatically.

**Fix:** Added `layout.refresh()` at the end of every `insert_from_dialog()` and `populate_distance_altitude_table()`.

### Bug C (IMPORTANT): "Load from layout" dropdown always empty in D/A dialog

**Root cause:** `_refresh_existing_tables` searched `layout.items()` for `QgsLayoutItemManualTable` instances — same wrong collection as Bug A.

**Fix:** Changed to `layout.multiFrames()`.

### Bug D (MINOR): "Refresh" button didn't refresh the existing-tables list

**Root cause:** `_reload_layouts()` repopulated the layout combo but `currentIndexChanged` only fires if the index changes. If the same layout stayed selected, the existing-tables combo went stale.

**Fix:** `_reload_layouts()` now calls `_attach_current_layout()` explicitly at the end.

### Bug E (MINOR): Needless `dlg.set_layout()` after dialog accepted

**Fix:** Removed the post-accept `dlg.set_layout(layout)` call from `insert_from_dialog()` in the D/A script.

### Additional Fixes Found During Review

**Fix: OCA/H table missing `setContentTextFormat()`** — D/A and GS/ROD scripts both set the table's content text format (font family + size), but OCA/H skipped it entirely. Text could render with wrong fonts or be invisible. Added the missing 3 lines.

**Fix: GS/ROD dialog always used `parent=None`** — D/A and OCA/H dialogs detect the active layout designer window and parent the dialog to it. GS/ROD didn't, so the dialog floated independently on Windows and could get lost behind other windows. Now uses the same parent detection logic.

**Fix: `insert_from_dialog` crashes could crash the plugin** — All 3 `dlg.accepted.connect(lambda: insert_from_dialog(...))` callbacks had no error handling. If any QGIS API call inside failed, the unhandled exception would crash the main thread. Added `_safe_insert()` wrapper that catches exceptions and shows a message bar warning instead.

**Fix: Redundant `setModal(False)` in all 3 dialogs** — `setWindowModality(Qt.NonModal)` already sets non-modal behavior. Removed the duplicate call from all 3 dialog constructors.

## Files Changed

| File | Changes |
|---|---|
| `qAeroChart/scripts/table_distance_altitude.py` | `TABLE_ID_PREFIX`, `_next_table_id()`, `frame.setId()`, `multiFrames()` fix, `layout.refresh()`, removed `dlg.set_layout()` |
| `qAeroChart/scripts/table_gs_rod.py` | Same naming + bug fixes |
| `qAeroChart/scripts/table_oca_h.py` | Same + added missing `setContentTextFormat()` |
| `qAeroChart/core/layout_manager.py` | `_TABLE_ID_PREFIX`, `_next_table_id()`, `frame.setId()`, `multiFrames()` fix, `layout.refresh()` |
| `qAeroChart/qaerochart.py` | `_safe_insert()` wrapper, GS/ROD parent window detection |
| `qAeroChart/ui/distance_altitude_table_dialog.py` | `multiFrames()` fix, `_reload_layouts` refresh fix, removed `setModal(False)` |
| `qAeroChart/ui/gs_rod_dialog.py` | Removed `setModal(False)` |
| `qAeroChart/ui/oca_h_dialog.py` | Removed `setModal(False)` |
| `tests/test_table_item_naming.py` | 24 new tests (naming + removal) |

## Test Results

```
419 passed in 0.72s
```

24 new tests added:
- `TestNextTableId` (11 tests) — all 3 prefixes, gaps, edge cases, zero-padding
- `TestRemoveExistingTable` (10 tests) — multiframe matching, no-ops, removes all duplicates
- `TestPrefixConstants` (3 tests) — prefix values correct

## How to Verify

1. Open a print layout in QGIS
2. Insert a Distance/Altitude table → Items panel shows `distance_table_001`
3. Insert again → old table removed, new one shows `distance_table_001` (re-numbered)
4. Insert a second D/A table without removing → shows `distance_table_002`
5. Insert GS/ROD table → `gs_table_001`
6. Insert OCA/H table → `oca_table_001`
7. Re-insert any table → layout designer updates immediately (no manual refresh needed)
8. Open D/A dialog → "Existing tables" dropdown shows tables in the layout
9. Click "Refresh" → dropdown updates with latest tables
