### PR TITLE
Issue #70: Fix "Load from Layout" for Distance/Altitude Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 .agent/
 .claude/
 skills-lock.json
+CLAUDE.md
 
 # cache
 .cache/

--- a/qAeroChart/ui/distance_altitude_table_dialog.py
+++ b/qAeroChart/ui/distance_altitude_table_dialog.py
@@ -89,6 +89,10 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
         self.combo_existing.setMinimumWidth(180)
         self.btn_load_existing = QtWidgets.QPushButton("Load from layout")
         self.btn_load_existing.clicked.connect(self._load_from_existing)
+        btn_refresh_existing = QtWidgets.QPushButton("Refresh")
+        btn_refresh_existing.setFixedWidth(60)
+        btn_refresh_existing.setToolTip("Reload tables from the current layout")
+        btn_refresh_existing.clicked.connect(self._refresh_existing_tables)
 
         row_btns = QtWidgets.QHBoxLayout()
         row_btns.setSpacing(6)
@@ -98,6 +102,7 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
         row_btns.addSpacing(12)
         row_btns.addWidget(QtWidgets.QLabel("Existing tables"))
         row_btns.addWidget(self.combo_existing)
+        row_btns.addWidget(btn_refresh_existing)
         row_btns.addWidget(self.btn_load_existing)
         row_btns.addStretch(1)
         controls.addLayout(row_btns, 1, 0, 1, 4)
@@ -259,45 +264,63 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
             return
         try:
             from qgis.core import QgsLayoutItemManualTable, QgsLayoutFrame
-
-            tables = [
-                mf for mf in self._layout.multiFrames()
-                if isinstance(mf, QgsLayoutItemManualTable)
-            ]
-            if not tables:
-                self.combo_existing.addItem("(no tables in layout)")
-                return
-            for idx, tbl in enumerate(tables):
-                label = tbl.customProperty("name") or f"Table {idx+1}"
-                info = self._extract_table(tbl)
-                if info:
-                    self._existing_tables.append(info)
-                    self.combo_existing.addItem(f"{label} ({len(info['rows'][0]) if info['rows'] else 0} cols)")
-        except Exception:
+        except ImportError:
             self.combo_existing.addItem("(cannot read tables)")
+            return
+
+        tables = [
+            mf for mf in self._layout.multiFrames()
+            if isinstance(mf, QgsLayoutItemManualTable)
+        ]
+        if not tables:
+            self.combo_existing.addItem("(no tables in layout)")
+            return
+
+        all_items = list(self._layout.items())
+        for idx, tbl in enumerate(tables):
+            # Use the frame item ID as label (unique: distance_table_001, etc.)
+            frames = [it for it in all_items
+                      if isinstance(it, QgsLayoutFrame) and it.multiFrame() == tbl]
+            label = (frames[0].id() if frames else None) or f"Table {idx + 1}"
+            info = self._extract_table(tbl)
+            if info is not None:
+                self._existing_tables.append(info)
+                cols = len(info["rows"][0]) if info.get("rows") else 0
+                self.combo_existing.addItem(f"{label} ({cols} cols)")
 
     def _extract_table(self, tbl):
         try:
             contents = tbl.tableContents()
-        except Exception:
+        except AttributeError:
             contents = []
+
         rows = []
+        for row in contents:
+            row_vals = []
+            for cell in row:
+                try:
+                    val = cell.content()
+                    # PyQt5/QGIS 3: content() returns QVariant
+                    # PyQt6/QGIS 4: content() returns a Python object directly
+                    if hasattr(val, "toString"):
+                        row_vals.append(val.toString())
+                    else:
+                        row_vals.append(str(val) if val is not None else "")
+                except AttributeError:
+                    row_vals.append("")
+            rows.append(row_vals)
+
+        col_widths = []
         try:
-            for row in contents:
-                row_vals = []
-                for cell in row:
-                    try:
-                        row_vals.append(cell.text())
-                    except Exception:
-                        row_vals.append("")
-                rows.append(row_vals)
-        except Exception:
-            rows = []
+            for w in tbl.columnWidths():
+                col_widths.append(float(w))
+        except (AttributeError, TypeError):
+            pass
 
         cfg = {
             "stroke": getattr(tbl, "gridStrokeWidth", lambda: 0.25)(),
             "cell_margin": getattr(tbl, "cellMargin", lambda: 0.0)(),
-            "column_widths": getattr(tbl, "columnWidths", lambda: [])(),
+            "column_widths": col_widths,
             "font_family": "Arial",
             "font_size": 8.0,
             "total_width": None,
@@ -308,15 +331,15 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
 
         try:
             fmt = tbl.contentTextFormat()
-            fnt = fmt.font()
-            cfg["font_family"] = fnt.family()
-            cfg["font_size"] = fmt.size()
-        except Exception:
+            cfg["font_family"] = fmt.font().family()
+            cfg["font_size"] = float(fmt.size())
+        except (AttributeError, TypeError, ValueError):
             pass
 
-        # Derive size/pos from first frame associated
         try:
-            frames = [it for it in self._layout.items() if isinstance(it, QgsLayoutFrame) and it.multiFrame() == tbl]
+            from qgis.core import QgsLayoutFrame
+            frames = [it for it in self._layout.items()
+                      if isinstance(it, QgsLayoutFrame) and it.multiFrame() == tbl]
             if frames:
                 frame = frames[0]
                 size = frame.sizeWithUnits()
@@ -325,7 +348,7 @@ class DistanceAltitudeTableDialog(QtWidgets.QDialog):
                 cfg["height"] = size.height()
                 cfg["x"] = pos.x()
                 cfg["y"] = pos.y()
-        except Exception:
+        except AttributeError:
             pass
 
         return {"rows": rows, "config": cfg}


### PR DESCRIPTION
# Plan — Issue #70: Fix "Load from Layout" for Distance/Altitude Table

## Root Cause Analysis

Three distinct bugs found in `qAeroChart/ui/distance_altitude_table_dialog.py`:

---

### Bug 1 — CRITICAL: Blank table on "Load from layout"

**Location**: `_extract_table()`, line ~289  
**Root cause**: The method calls `cell.text()` on `QgsTableCell` objects. The QGIS API has **no `text()` method** on `QgsTableCell` — the correct method is `content()` (confirmed from official PyQGIS master docs).  
The bare `except Exception` silently catches the `AttributeError` and appends `""` for every cell → the loaded table is always empty.

```python
# WRONG — text() does not exist on QgsTableCell
row_vals.append(cell.text())

# CORRECT — content() returns Any (Python obj in PyQt6/QGIS 4, QVariant in PyQt5/QGIS 3)
val = cell.content()
row_vals.append(str(val) if val is not None else "")
```

---

### Bug 2 — MEDIUM: All tables show the same label in the combo

**Location**: `_refresh_existing_tables()`, line ~271  
**Root cause**: `tbl.customProperty("name")` is always `"distance_altitude_table"` (the constant `TABLE_NAME`) because `_build_table()` sets the same custom property on every table it creates. The unique sequential IDs (`distance_table_001`, `distance_table_002`) are set only on the **frame**, not the multi-frame. So the combo always shows `"distance_altitude_table (6 cols)"` × N.

**Fix**: Retrieve the label from the first associated frame's `id()`:
```python
frames = [it for it in self._layout.items()
          if isinstance(it, QgsLayoutFrame) and it.multiFrame() == tbl]
label = frames[0].id() if frames else (tbl.customProperty("name") or f"Table {idx+1}")
```

---

### Bug 3 — UX: No refresh for "Existing tables" combo

**Location**: `_build_ui()` — the row with `combo_existing`  
**Root cause**: The combo is only refreshed when the selected layout changes. If the user adds a new table while the dialog is open (non-modal), the combo doesn't update and the new table is invisible. A "Refresh" button wired to `_refresh_existing_tables()` is needed next to the combo.

---

## File to Modify

| File | Change |
|------|--------|
| `qAeroChart/ui/distance_altitude_table_dialog.py` | Fix `_extract_table()` + `_refresh_existing_tables()` + add Refresh button |

No other files need changing.

---

## Implementation Phases

### Phase 1 — Fix cell content reading (Bug 1)

In `_extract_table()`, replace the `cell.text()` call with `cell.content()` and handle both PyQt5 (QVariant) and PyQt6 (native Python obj):

```python
val = cell.content()
# PyQt5/QGIS 3: content() returns QVariant → call toString()
# PyQt6/QGIS 4: content() returns Python object directly
if hasattr(val, 'toString'):
    row_vals.append(val.toString())
else:
    row_vals.append(str(val) if val is not None else "")
```

Also narrow the bare `except Exception` blocks to specific exceptions to avoid silent masking.

### Phase 2 — Fix table label in combo (Bug 2)

In `_refresh_existing_tables()`, look up the first frame associated with each multi-frame to use its `id()` as the display label:

```python
frames = [it for it in self._layout.items()
          if isinstance(it, QgsLayoutFrame) and it.multiFrame() == tbl]
label = frames[0].id() if frames else (tbl.customProperty("name") or f"Table {idx+1}")
```

### Phase 3 — Add Refresh button for existing tables (Bug 3)

In `_build_ui()`, add a small "Refresh" button next to `combo_existing`:

```python
btn_refresh_existing = QtWidgets.QPushButton("Refresh")
btn_refresh_existing.setFixedWidth(60)
btn_refresh_existing.setToolTip("Reload tables from the current layout")
btn_refresh_existing.clicked.connect(self._refresh_existing_tables)
```

Insert it after `self.btn_load_existing` in `row_btns`.

---

## Risks

| Risk | Mitigation |
|------|------------|
| `content()` returns different types in PyQt5 vs PyQt6 | Use `hasattr(val, 'toString')` guard |
| `layout.items()` is slow on large layouts | Frame lookup is only called in `_refresh_existing_tables()` (user-triggered), not in a hot path |
| Narrowing `except` may surface previously hidden errors | Errors will now propagate correctly (desired behaviour) |
